### PR TITLE
fix compatibility with Godot 4.6

### DIFF
--- a/Godot Secure AES-256.py
+++ b/Godot Secure AES-256.py
@@ -55,16 +55,22 @@ def version_tuple(version_str) -> tuple:
         return (4, 6)
 
 def should_apply_operation(op, major_version, minor_version) -> bool:
-    # Determine if an operation should be applied based on min/max versions
+    # Filters operations based on version constraints
+    # Examples:
+    #   version_min: 4.6,  applies to 4.6 and newer
+    #   version_max: 4.5, applies to 4.5 and older
+    #   Both: 4.3 + 4.5, applies only to 4.3-4.5 range
+    #   Nothing: applies to everything
+    
     current_version = (major_version, minor_version)
     
-    # Check version_min
+    # Reject if current version is below minimum required
     if "version_min" in op:
         min_version = version_tuple(op["version_min"])
         if current_version < min_version:
             return False
     
-    # Check version_max
+    # Reject if current version is above maximum supported
     if "version_max" in op:
         max_version = version_tuple(op["version_max"])
         if current_version > max_version:
@@ -203,7 +209,7 @@ MODIFICATIONS = [
             {
                 "type": "replace_block",
                 "description": "Add token obfuscation for encryption",
-                "version_min": "4.6",
+                "version_min": "4.6", # applies to 4.6 and everything above
                 "find": [
                     "CryptoCore::AESContext ctx;",
                     "ctx.set_encode_key(key.ptrw(), 256);",
@@ -245,7 +251,7 @@ MODIFICATIONS = [
             {
                 "type": "replace_block",
                 "description": "Add token obfuscation for encryption",
-                "version_max": "4.5", 
+                "version_max": "4.5", # applies to 4.5 and everything below
                 "find": [
                     "CryptoCore::AESContext ctx;",
                     "ctx.set_encode_key(key.ptrw(), 256);",

--- a/Godot Secure Camellia-256.py
+++ b/Godot Secure Camellia-256.py
@@ -55,16 +55,20 @@ def version_tuple(version_str) -> tuple:
         return (4, 6)  # default to 4.6+ for resilience
 
 def should_apply_operation(op, major_version, minor_version) -> bool:
-    # Determine if an operation should be applied based on min/max versions
+    # Filters operations based on version constraints
+    # Examples:
+    #   version_min: 4.6,  applies to 4.6 and newer
+    #   version_max: 4.5, applies to 4.5 and older
+    #   Both: 4.3 + 4.5, applies only to 4.3-4.5 range
     current_version = (major_version, minor_version)
     
-    # Check version_min
+    # Reject if current version is below minimum required
     if "version_min" in op:
         min_version = version_tuple(op["version_min"])
         if current_version < min_version:
             return False
     
-    # Check version_max
+    # Reject if current version is above maximum supported
     if "version_max" in op:
         max_version = version_tuple(op["version_max"])
         if current_version > max_version:
@@ -203,7 +207,7 @@ MODIFICATIONS = [
             {
                 "type": "replace_block",
                 "description": "Add token obfuscation for encryption",
-                "version_min": "4.6",
+                "version_min": "4.6", # applies to 4.6 and everything above
                 "find": [
                     "CryptoCore::AESContext ctx;",
                     "ctx.set_encode_key(key.ptrw(), 256);",
@@ -245,7 +249,7 @@ MODIFICATIONS = [
             {
                 "type": "replace_block",
                 "description": "Add token obfuscation for encryption (pre-4.6)",
-                "version_max": "4.5",
+                "version_max": "4.5", # applies to 4.5 and everything below
                 "find": [
                     "CryptoCore::AESContext ctx;",
                     "ctx.set_encode_key(key.ptrw(), 256);",


### PR DESCRIPTION
### When trying to use this in Godot 4.6, the following error occurs.

<img width="1140" height="168" alt="error" src="https://github.com/user-attachments/assets/7ab66a60-8339-43cb-88bf-6ef6f83cd2ac" />

This happens because a few lines in the target file, file_access_encrypt.cpp, were changed.

The solution was very simple: i updated the lines in Godot Secure AES-256.py to match those in the .cpp file.

## current file:
<img width="951" height="256" alt="w" src="https://github.com/user-attachments/assets/fcff30dc-7562-4d8a-ab13-6a650bbea26b" />

## new file (4.6 file_access_encrypted.cpp && my .py):

<img width="1657" height="355" alt="new_code" src="https://github.com/user-attachments/assets/62acc993-c6f8-44ee-9c63-e871944cfc7e" />


<img width="1657" height="355" alt="new_code_draw" src="https://github.com/user-attachments/assets/09302907-c94a-4ab0-acb9-e6afa5f2fd8a" />


Now, when we run the .py file in Godot again

<img width="1077" height="303" alt="success" src="https://github.com/user-attachments/assets/ad455a12-c1c1-44c4-8224-f7031884feb6" />

I've made the same modifications to AES and Camilla
