### PR TITLE
Added wizard scripts

### DIFF
--- a/Godot Secure Scripts/run.bat
+++ b/Godot Secure Scripts/run.bat
@@ -1,0 +1,244 @@
+@echo off
+setlocal enabledelayedexpansion
+:: @author: Twister
+:: @contact: https://github.com/CodeNameTwister
+:: @license: Twister Wasting Time Copyrights by a company that wastes time, all time is reserved.
+
+
+:: Godot Secure Version
+cls
+SET VER=4.0
+
+echo Godot Secure Version %VER% Github: https://github.com/KnifeXRage/Godot-Secure
+
+echo [94m
+echo "::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::"
+echo " _____           _       _     _____                          "
+echo "|  __ \         | |     | |   /  ___|                         "
+echo "| |  \/ ___   __| | ___ | |_  \ `--.  ___  ___ _   _ _ __ ___ "
+echo "| | __ / _ \ / _` |/ _ \| __|  `--. \/ _ \/ __| | | | '__/ _ \"
+echo "| |_\ \ (_) | (_| | (_) | |_  /\__/ /  __/ (__| |_| | | |  __/"
+echo " \____/\___/ \__,_|\___/ \__| \____/ \___|\___|\__,_|_|  \___|"
+echo "::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::"
+echo [0m
+
+:: init 1
+:: ========================================================
+
+:: =======================
+::      CHECK P11T0N
+:: =======================
+SET __PY__=python
+
+where %__PY__% >nul 2>&1
+if %errorlevel% neq 0 (
+    where py >nul 2>&1
+    if %errorlevel% neq 0 (
+        :: init 0
+        echo [[91mCRITICAL[0m] Python is not installed or can not find in the environment PATH.      
+        echo You can download python on "https://www.python.org" and make sure add python to environment PATH.
+        pause
+        exit /b 1
+    )
+
+    SET __PY__=py
+)
+
+%__PY__% -c "import sys; exit(0) if sys.version_info >= (3, 10) else exit(1)" >nul 2>&1
+
+if %errorlevel% neq 0 (
+    :: init 0
+    echo [[91mERROR[0m] Python version >= 3.10 is required!, you can download in: "https://www.python.org"
+    echo You current version:
+    %__PY__% --version
+    pause
+    exit /b %errorlevel%
+)
+
+echo [[92mOK[0m] Python is installed.
+
+:: X1 MM
+:: ========================================================
+
+SET _ST=0
+SET __DIR__=%~dp0
+
+:INIT
+
+SET _OP[0]=4
+SET "_OP[1]=Set Encryption Key"
+SET "_OP[2]=Run Godot Secure Script"
+SET "_OP[3]=Restore Backup Files"
+SET "_OP[4]=[93mExit[0m"
+
+SET _FNC[0]=INIT
+SET _FNC[1]=SET_KEY
+SET _FNC[2]=MENU_VER
+SET _FNC[3]=MENU_RESTORE
+SET _FNC[4]=EXIT
+
+if %_ST% GTR 0 (
+   CLS
+)
+
+SET _ST=1
+
+echo [94m
+echo ====================================
+echo        Godot-Secure Options
+echo ====================================
+
+:_OP_
+echo [93mMenu[92m
+
+for /L %%i in (1,1,%_OP[0]%) do (
+    echo %%i. !_OP[%%i]!
+)
+
+echo.
+
+SET /p op="Select an option (1-%_OP[0]%): "
+
+
+if %op% GTR 0 (
+    if %op% LEQ %_OP[0]% (
+        goto !_FNC[%op%]!
+    )
+)
+
+echo Invalid selection, try again.
+pause
+goto !_FNC[0]!
+
+:: X2 SM
+:: ========================================================
+:SET_KEY
+    CLS
+    echo [94m
+    echo ====================================
+    echo           Encryption Key
+    echo ====================================
+    echo [0mSet you generated 256-bit key[92m
+    echo/
+
+    SET /p op="Encryption Key:"
+    SET SCRIPT_AES256_ENCRYPTION_KEY=$op
+
+    goto INIT
+
+:MENU_VER
+CLS
+echo [94m
+echo ====================================
+echo           GODOT VERSION
+echo ====================================
+echo [0mWhat is you Godot Version?[92m
+echo.
+
+SET _OP[0]=3
+SET "_OP[1]=Godot 4.6 or greater"
+SET "_OP[2]=Godot 4.5 or minor"
+SET "_OP[3]=[93mBack[0m"
+
+SET _FNC[0]=MENU_VER
+SET _FNC[1]=MENU_4_6
+SET _FNC[2]=MENU_4_5
+SET _FNC[%_OP[0]%]=INIT
+
+goto _OP_
+
+:MENU_4_6
+SET fscript=v4.6.x - Latest
+SET fback=MENU_4_6
+goto LIST
+
+:MENU_4_5
+SET fscript=v4.x.x - v4.5.x
+SET fback=MENU_4_5
+goto LIST
+
+:LIST
+CLS
+echo [94m
+echo ====================================
+echo            SELECT SCRIPT
+echo ====================================
+SET /a xfiles=0
+for /f "delims=" %%f in ('dir /b /a-d "%__DIR__%%fscript%\*.py" 2^>nul') do ( 
+    SET /a xfiles+=1
+    SET _OP[!xfiles!]=%%f
+)
+SET /a xfiles+=1
+SET "_OP[0]=%xfiles%"
+SET "_OP[%xfiles%]=[93mBack[0m"
+
+for /L %%i in (1,1,%xfiles%) do (
+    SET "_FNC[%%i]=RUN_SCRIPT"
+)
+
+SET _FNC[0]=%fback%
+SET _FNC[%xfiles%"]=MENU_VER
+
+goto _OP_
+
+:RUN_SCRIPT
+CLS
+echo [92mScript selected !_OP[%op%]![0m
+
+echo.
+echo Please set the "godot" directory
+echo (Example: "C:/my_folder/godot")
+echo.
+SET /p gd="Godot directory: "
+echo Trying use the godot directory: %gd%
+echo Starting run Godot Secure Script...
+echo.
+%__PY__% "%__DIR__%%fscript%\!_OP[%op%]!" %gd%
+echo.
+echo Operation ended, back to main menu.
+pause
+GOTO INIT
+
+:MENU_RESTORE
+CLS
+echo [94m
+echo ====================================
+echo        RESTORE BACKUP
+echo ====================================
+echo [0mAre you sure restore backup?[92m
+echo.
+SET _OP[0]=2
+SET "_OP[1]=Yes"
+SET "_OP[2]=[93mNo[0m"
+
+SET _FNC[0]=MENU_RESTORE
+SET _FNC[1]=RESTORE_BACKUP
+SET _FNC[2]=INIT
+
+goto _OP_
+
+:RESTORE_BACKUP
+CLS
+echo [92mStarting Restore Backup...[0m
+echo.
+echo Please set the "godot" directory
+echo (Example: "C:/my_folder/godot")
+echo.
+
+SET /p gd="Godot directory: "
+echo Trying use the godot directory: %gd%
+%__PY__% "%__DIR___%utils/restore_backup.py" %gd%
+echo.
+echo Operation ended, back to main menu.
+pause
+
+goto INIT
+
+goto EXIT
+
+:: X0 SIGTERM
+:: ========================================================
+:EXIT
+echo Exiting...
+timeout /t 2 >nul
+exit

--- a/Godot Secure Scripts/run.ps1
+++ b/Godot Secure Scripts/run.ps1
@@ -1,0 +1,249 @@
+# :: @author: Twister
+# :: @contact: https://github.com/CodeNameTwister
+# :: @license: Twister Wasting Time Copyrights by a company that wastes time, all time is reserved.
+
+# :: Godot Secure Version
+Clear-Host
+$VER = "4.0"
+
+Write-Host "Godot Secure Version $VER Github: https://github.com/KnifeXRage/Godot-Secure"
+
+Write-Host -ForegroundColor Cyan "::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::"
+Write-Host -ForegroundColor Cyan " _____           _       _     _____                          "
+Write-Host -ForegroundColor Cyan "|  __ \         | |     | |   /  ___|                         "
+Write-Host -ForegroundColor Cyan "| |  \/ ___   __| | ___ | |_  \ \`--.  ___  ___ _   _ _ __ ___"
+Write-Host -ForegroundColor Cyan "| | __ / _ \ / _\` |/ _ \| __|  \`--. \/ _ \/ __| | | | '__/ _ \"
+Write-Host -ForegroundColor Cyan "| |_\ \ (_) | (_| | (_) | |_  /\__/ /  __/ (__| |_| | | |  __/"
+Write-Host -ForegroundColor Cyan " \____/\___/ \__,_|\___/ \__| \____/ \___|\___|\__,_|_|  \___|"
+Write-Host -ForegroundColor Cyan "::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::"
+
+# :: init 1
+# :: =======================
+# ::      CHECK P11T0N
+# :: =======================
+$__PY__ = "python"
+
+if (-not (Get-Command $__PY__ -ErrorAction SilentlyContinue)) {
+    if (-not (Get-Command py -ErrorAction SilentlyContinue)) {
+        # :: init 0
+        Write-Host "[ " -NoNewline; Write-Host -ForegroundColor Red "CRITICAL" -NoNewline; Write-Host " ] Python is not installed or can not find in the environment PATH."
+        Write-Host "You can download python on `"https://www.python.org`" and make sure add python to environment PATH."
+        Pause
+        exit 1
+    }
+    $__PY__ = "py"
+}
+
+& $__PY__ -c "import sys; exit(0) if sys.version_info >= (3, 10) else exit(1)"
+if ($LASTEXITCODE -ne 0) {
+    # :: init 0
+    Write-Host "[ " -NoNewline; Write-Host -ForegroundColor Red "ERROR" -NoNewline; Write-Host " ] Python version >= 3.10 is required!, you can download in: `"https://www.python.org`""
+    Write-Host "You current version:"
+    & $__PY__ --version
+    Pause
+    exit $LASTEXITCODE
+}
+
+Write-Host "[ " -NoNewline; Write-Host -ForegroundColor Green "OK"  -NoNewline; Write-Host " ] Python is installed."
+# :: X1 MM
+# :: ========================================================
+
+$_ST = 0
+$__DIR__ = $PSScriptRoot
+
+function INIT {
+    $global:_OP = @{}
+    $global:_OP[0] = 4
+    $global:_OP[1] = "Set Encryption Key"
+    $global:_OP[2] = "Run Godot Secure Script"
+    $global:_OP[3] = "Restore Backup Files"
+    $global:_OP[4] = "Exit"
+
+    $global:_FNC = @{}
+    $global:_FNC[0] = "INIT"
+    $global:_FNC[1] = "SET_KEY"
+    $global:_FNC[2] = "MENU_VER"
+    $global:_FNC[3] = "MENU_RESTORE"
+    $global:_FNC[4] = "EXIT_FUNC"
+
+    if ($_ST -gt 0) {
+        Clear-Host
+    }
+
+    $_ST = 1
+
+    Write-Host -ForegroundColor Cyan "===================================="
+    Write-Host -ForegroundColor Cyan "        Godot-Secure Options"
+    Write-Host -ForegroundColor Cyan "===================================="
+
+    _OP_
+}
+
+function _OP_ {
+    Write-Host -ForegroundColor Yellow "Menu " -NoNewline; Write-Host -ForegroundColor Green ""
+    
+    for ($i = 1; $i -le $_OP[0]; $i++) {
+        if ($i -eq $_OP[0]) {
+            Write-Host "$i. " -NoNewline; Write-Host -ForegroundColor Yellow "$($_OP[$i])"
+        } else {
+            Write-Host "$i. $($_OP[$i])"
+        }
+    }
+
+    Write-Host ""
+    $op = Read-Host "Select an option (1-$($_OP[0]))"
+
+    if ($op -gt 0 -and $op -le $_OP[0]) {
+        $target = $_FNC[[int]$op]
+        & $target
+    } else {
+        Write-Host "Invalid selection, try again."
+        Pause
+        & $_FNC[0]
+    }
+}
+
+# :: X2 SM
+# :: ========================================================
+function SET_KEY {
+    Clear-Host
+    Write-Host -ForegroundColor Cyan "===================================="
+    Write-Host -ForegroundColor Cyan "           Encryption Key"
+    Write-Host -ForegroundColor Cyan "===================================="
+    Write-Host "Set you generated 256-bit key " -NoNewline; Write-Host -ForegroundColor Green ""
+    Write-Host ""
+
+    $op = Read-Host "Encryption Key"
+    $env:SCRIPT_AES256_ENCRYPTION_KEY = $op
+
+    INIT
+}
+
+function MENU_VER {
+    Clear-Host
+    Write-Host -ForegroundColor Cyan "===================================="
+    Write-Host -ForegroundColor Cyan "           GODOT VERSION"
+    Write-Host -ForegroundColor Cyan "===================================="
+    Write-Host "What is you Godot Version?"
+    Write-Host ""
+
+    $global:_OP = @{}
+    $global:_OP[0] = 3
+    $global:_OP[1] = "Godot 4.6 or greater"
+    $global:_OP[2] = "Godot 4.5 or minor"
+    $global:_OP[3] = "Back"
+
+    $global:_FNC = @{}
+    $global:_FNC[0] = "MENU_VER"
+    $global:_FNC[1] = "MENU_4_6"
+    $global:_FNC[2] = "MENU_4_5"
+    $global:_FNC[3] = "INIT"
+
+    _OP_
+}
+
+function MENU_4_6 {
+    $global:fscript = "v4.6.x - Latest"
+    $global:fback = "MENU_4_6"
+    LIST
+}
+
+function MENU_4_5 {
+    $global:fscript = "v4.x.x - v4.5.x"
+    $global:fback = "MENU_4_5"
+    LIST
+}
+
+function LIST {
+    Clear-Host
+    Write-Host -ForegroundColor Cyan "===================================="
+    Write-Host -ForegroundColor Cyan "            SELECT SCRIPT"
+    Write-Host -ForegroundColor Cyan "===================================="
+    
+    $global:xfiles = 0
+    $global:_OP = @{}
+    $global:_FNC = @{}
+    
+    $files = Get-ChildItem -Path "$__DIR__\$fscript\*.py" -ErrorAction SilentlyContinue
+    foreach ($f in $files) {
+        $global:xfiles++
+        $global:_OP[$xfiles] = $f.Name
+        $global:_FNC[$xfiles] = "RUN_SCRIPT"
+    }
+    
+    $global:xfiles++
+    $global:_OP[0] = $xfiles
+    $global:_OP[$xfiles] = "Back"
+    $global:_FNC[0] = $global:fback
+    $global:_FNC[$xfiles] = "MENU_VER"
+
+    _OP_
+}
+
+function RUN_SCRIPT {
+    Clear-Host
+    Write-Host -ForegroundColor Green "Script selected $($global:_OP[[int]$op])"
+
+    Write-Host ""
+    Write-Host "Please set the `"godot`" directory"
+    Write-Host "(Example: `"C:/my_folder/godot`")"
+    Write-Host ""
+    $gd = Read-Host "Godot directory"
+    Write-Host "Trying use the godot directory: $gd"
+    Write-Host "Starting run Godot Secure Script..."
+    Write-Host ""
+    & $__PY__ "$__DIR__\$fscript\$($_OP[[int]$op])" $gd
+    Write-Host ""
+    Write-Host "Operation ended, back to main menu."
+    Pause
+    INIT
+}
+
+function MENU_RESTORE {
+    Clear-Host
+    Write-Host -ForegroundColor Cyan "===================================="
+    Write-Host -ForegroundColor Cyan "        RESTORE BACKUP"
+    Write-Host -ForegroundColor Cyan "===================================="
+    Write-Host "Are you sure restore backup?"
+    Write-Host ""
+    
+    $global:_OP = @{}
+    $global:_OP[0] = 2
+    $global:_OP[1] = "Yes"
+    $global:_OP[2] = "No"
+
+    $global:_FNC = @{}
+    $global:_FNC[0] = "MENU_RESTORE"
+    $global:_FNC[1] = "RESTORE_BACKUP"
+    $global:_FNC[2] = "INIT"
+
+    _OP_
+}
+
+function RESTORE_BACKUP {
+    Clear-Host
+    Write-Host -ForegroundColor Green "Starting Restore Backup..."
+    Write-Host ""
+    Write-Host "Please set the `"godot`" directory"
+    Write-Host "(Example: `"C:/my_folder/godot`")"
+    Write-Host ""
+
+    $gd = Read-Host "Godot directory"
+    Write-Host "Trying use the godot directory: $gd"
+    & $__PY__ "$__DIR__\utils\restore_backup.py" $gd
+    Write-Host ""
+    Write-Host "Operation ended, back to main menu."
+    Pause
+
+    INIT
+}
+
+# :: X0 SIGTERM
+# :: ========================================================
+function EXIT_FUNC {
+    Write-Host "Exiting..."
+    Start-Sleep -Seconds 2
+    exit
+}
+
+INIT

--- a/Godot Secure Scripts/run.sh
+++ b/Godot Secure Scripts/run.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+
+# @author: Twister
+# @contact: https://github.com/CodeNameTwister
+# @license: Twister Wasting Time Copyrights by a company that wastes time, all time is reserved.
+
+
+# Godot Secure Version
+clear
+VER='4.0'
+
+echo "Godot Secure Version $VER Github: 'https://github.com/KnifeXRage/Godot-Secure'"
+
+echo '[94m'
+echo '::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::'
+echo ' _____           _       _     _____                          '
+echo '|  __ \         | |     | |   /  ___|                         '
+echo '| |  \/ ___   __| | ___ | |_  \ `--.  ___  ___ _   _ _ __ ___ '
+echo '| | __ / _ \ / _` |/ _ \| __|  `--. \/ _ \/ __| | | | '__/ ___'\'
+echo '| |_\ \ (_) | (_| | (_) | |_  /\__/ /  __/ (__| |_| | | |  __/'
+echo ' \____/\___/ \__,_|\___/ \__| \____/ \___|\___|\__,_|_|  \___|'
+echo '::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::'
+echo '[0m'
+
+# init 1
+# ========================================================
+
+# =======================
+#      CHECK P11T0N
+# =======================
+__PY__='python'
+__OMSG__='Press any key to continue...'
+
+if !command -v $__PY__ &> /dev/null; then
+    if !command -v py &> /dev/null; then
+        echo "Python no está instalado."
+        # init 0
+        echo '[[91mCRITICAL[0m] Python is not installed or can not find in the environment PATH.'
+        echo 'You can download python on "https://www.python.org" and make sure add python to environment PATH.'
+        read -p "$__OMSG__"
+        exit /b 1
+    fi
+    __PY__='py'
+fi
+
+command $__PY__ -c "import sys; exit(0) if sys.version_info >= (3, 10) else exit(1)" >nul 2>&1
+
+if [ $? -ne 0 ]; then
+    # init 0
+    echo '[[91mERROR[0m] Python version >= 3.10 is required!, you can download in: "https://www.python.org"'
+    echo 'You current version:'
+    command $__PY__ --version
+    read -p "$__OMSG__"
+    exit $?
+fi
+
+echo '[[92mOK[0m] Python is installed.'
+
+# X1 MM
+# ========================================================
+
+_ST=0
+__DIR__="$(dirname "$0")"
+
+init(){
+    _OP[0]=4
+    _OP[1]='Set Encryption Key'
+    _OP[2]='Run Godot Secure Script'
+    _OP[3]='Restore Backup Files'
+    _OP[4]='[93mExit[0m'
+
+    _FNC[0]='init'
+    _FNC[1]='set_key'
+    _FNC[2]='menu_ver'
+    _FNC[3]='menu_restore'
+    _FNC[4]='_exit'
+
+    if [ $_ST -gt 0 ]; then
+        clear
+    fi
+
+    _ST=1
+
+    echo '[94m'
+    echo '===================================='
+    echo '        Godot-Secure Options'
+    echo '===================================='
+
+    echo;
+
+    
+    _op_
+}
+
+_op_(){
+    next='_back'
+    echo '[93mMenu[92m'
+
+    for i in $(seq 1 ${_OP[0]}); do
+        echo "$i. ${_OP[$i]}"
+    done
+    echo;
+    read -p "Select an option :(1-${_OP[0]}): " op
+
+    if ! [[ $op =~ ^[0-9]+$ ]]; then
+        op=-1
+    fi
+
+    if [ $op -gt 0 ]; then
+        if [ $op -le ${_OP[0]} ]; then
+            next=${_FNC[$op]}
+        fi
+    fi
+    $next
+}
+
+_back(){
+    echo 'Invalid selection, try again.'
+    read -p "$__OMSG__"
+    ${_FNC[0]}
+}
+
+:: X2 SM
+:: ========================================================
+set_key(){
+    clear
+    echo '[94m'
+    echo '===================================='
+    echo '          Encryption Key'
+    echo '===================================='
+    echo '[0mSet you generated 256-bit key[92m'
+    echo;
+
+    read -p "Encryption key:" op
+    export SCRIPT_AES256_ENCRYPTION_KEY=$op
+
+    init
+}
+
+menu_ver(){
+    clear
+    echo '[94m'
+    echo '===================================='
+    echo '          GODOT VERSION'
+    echo '===================================='
+    echo '[0mWhat is you Godot Version?[92m'
+    echo;
+
+    _OP[0]=3
+    _OP[1]='Godot 4.6 or greater'
+    _OP[2]='Godot 4.5 or minor'
+    _OP[3]='[93mBack[0m'
+    
+    _FNC[0]='menu_ver'
+    _FNC[1]='menu_4_6'
+    _FNC[2]='menu_4_5'
+    _FNC[${_OP[0]}]='init'
+
+    _op_
+}
+
+menu_4_6(){
+    fscript='v4.6.x - Latest'
+    fback='menu_4_6'
+    list
+}
+
+menu_4_5(){
+    fscript='v4.x.x - v4.5.x'
+    fback='menu_4_5'
+    list
+}
+
+list(){
+    clear
+    echo '[94m'
+    echo '===================================='
+    echo '           SELECT SCRIPT'
+    echo '===================================='
+    xfiles=0
+
+    for f in "$__DIR__/$fscript"/*.py; do
+        [ -e "$f" ] || continue
+        ((xfiles++))
+        _OP[$xfiles]=$(basename "$f")
+    done
+
+    ((xfiles++))
+    _OP[0]=$xfiles
+    _OP[$xfiles]="[93mBack[0m"
+
+
+    for (( i=1; i<=$xfiles; i++ )); do
+        _FNC[$i]="run_script"
+    done
+
+    _FNC[0]=$fback
+    _FNC[$xfiles]='menu_ver'
+
+    _op_
+}
+
+run_script(){
+    clear
+    echo "[92mScript selected ${_OP[$op]}[0m"
+
+    echo;
+    echo 'Please set the "godot" directory'
+    echo '(Example: "C:/my_folder/godot")'
+    echo;
+    read -p "Godot directory:" gd
+    echo "Trying use godot directory: $gd"
+    echo Starting run Godot Secure Script...
+    echo;
+    command $__PY__ "$__DIR__/$fscript/${_OP[$op]}" $gd
+    echo;
+    echo 'Operation ended, back to main menu.'
+    read -p "$__OMSG__"
+    init
+}
+
+menu_restore(){
+    clear
+    echo '[94m'
+    echo '===================================='
+    echo '       RESTORE BACKUP'
+    echo '===================================='
+    echo '[0mAre you sure restore backup?[92m'
+    echo;
+    _OP[0]=2
+    _OP[1]='Yes'
+    _OP[2]='[93mNo[0m'
+
+    _FNC[0]='menu_restore'
+    _FNC[1]='restore_backup'
+    _FNC[2]='init'
+
+    _op_
+}
+
+restore_backup(){
+    clear
+    echo '[92mStarting Restore Backup...[0m'
+    echo;
+    echo 'Please set the "godot" directory'
+    echo '(Example: "C:/my_folder/godot")'
+    echo;
+
+    read -p "Godot directory:" gd
+    echo "Trying use godot directory: $gd"
+
+    command $__PY__ "$__DIR__/utils/restore_backup.py" $gd
+    echo;
+    echo 'Operation ended, back to main menu.'
+    read -p "$__OMSG__"
+
+    init
+}
+
+_exit(){
+    #X0 SIGTERM
+    echo Exiting...
+    exit 0
+}
+
+init

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Standard Godot encryption has known vulnerabilities. Our solution:
 >Must Read Godot's Official Documentation:
 >🔗[View Official Documentation](https://docs.godotengine.org/en/stable/contributing/development/compiling/index.html)
 
+
+
 ### Step 1: Prepare Environment
 ```bash
 git clone https://github.com/godotengine/godot.git
@@ -84,6 +86,20 @@ python godot_secure.py /path/to/godot_source/
 
 #Example:
 python godot_secure.py godot/
+```
+
+### Alternative Step 3
+> You can use the friendly wizard's execution script.
+> Using: the file called `run`
+```bash
+# For Linux/macOS:
+use "run.sh"
+
+# For Window
+use "run.bat"
+
+# For Powershell
+use "run.ps1"
 ```
 
 ### Step 4: Compile Godot Engine and Export Templates


### PR DESCRIPTION
This pull provides an easy-to-use alternative on the console for new users who wish to use Godot Secure.

<img width="608" height="342" alt="image" src="https://github.com/user-attachments/assets/1c7f0890-27f5-483c-9358-d4c8f051b669" />

That would be a functional concept; I say concept because the set encryption key wouldn't make sense for this scope after looking more closely at the code. Since I already had it done, I decided to add it anyway for the pull.
